### PR TITLE
Add syntax highlight for Go, Rust, and Swift between backticks

### DIFF
--- a/MarkdownLight.tmLanguage
+++ b/MarkdownLight.tmLanguage
@@ -763,6 +763,34 @@
 				</dict>
 				<dict>
 					<key>begin</key>
+					<string>(\s*```)\s*(go|golang)\s*$</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.fenced.markdown</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.language.fenced.markdown</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(\1)\n</string>
+					<key>name</key>
+					<string>markup.raw.block.markdown markup.raw.block.fenced.markdown</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>source.go</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
 					<string>(\s*```)\s*([^\s`]*)\s*$</string>
 					<key>captures</key>
 					<dict>

--- a/MarkdownLight.tmLanguage
+++ b/MarkdownLight.tmLanguage
@@ -819,6 +819,34 @@
 				</dict>
 				<dict>
 					<key>begin</key>
+					<string>(\s*```)\s*(swift)\s*$</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.fenced.markdown</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.language.fenced.markdown</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(\1)\n</string>
+					<key>name</key>
+					<string>markup.raw.block.markdown markup.raw.block.fenced.markdown</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>source.swift</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
 					<string>(\s*```)\s*([^\s`]*)\s*$</string>
 					<key>captures</key>
 					<dict>

--- a/MarkdownLight.tmLanguage
+++ b/MarkdownLight.tmLanguage
@@ -791,6 +791,34 @@
 				</dict>
 				<dict>
 					<key>begin</key>
+					<string>(\s*```)\s*(rs|rust)\s*$</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.fenced.markdown</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.language.fenced.markdown</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(\1)\n</string>
+					<key>name</key>
+					<string>markup.raw.block.markdown markup.raw.block.fenced.markdown</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>source.rust</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
 					<string>(\s*```)\s*([^\s`]*)\s*$</string>
 					<key>captures</key>
 					<dict>


### PR DESCRIPTION
[Go](https://golang.org/) — [Rust](https://www.rust-lang.org/) — [Swift](https://developer.apple.com/swift/) are popular programming languages that many developers are using for very interesting projects. In my specific case I have used them both in personal projects and to write about in my blog. This PR adds support for syntax-highlighting. If anyone else is interested in writing code in any of these tree languages while editing a Markdown file then these changes will be helpful.

**Note:** Swift is not supported by SublimeText, but there is a 3rd-party package — [Swift for ST3](https://packagecontrol.io/packages/Swift)
